### PR TITLE
Add Javadoc comments and default constructor to SampleDataStore

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/sample/SampleDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/sample/SampleDataStore.java
@@ -36,8 +36,20 @@ import org.codelibs.fess.mylasta.direction.FessConfig;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
+/**
+ * This class is a sample data store implementation for Fess.
+ * It generates sample documents for crawling and indexing.
+ * The number of documents can be configured via the "data.size" parameter.
+ */
 public class SampleDataStore extends AbstractDataStore {
     private static final Logger logger = LogManager.getLogger(SampleDataStore.class);
+
+    /**
+     * Default constructor.
+     */
+    public SampleDataStore() {
+        super();
+    }
 
     @Override
     protected String getName() {


### PR DESCRIPTION
This pull request improves the readability and documentation of the SampleDataStore class by:

- Adding Javadoc comments to the class and its constructor.
- Introducing an explicit default constructor calling the superclass constructor.

These changes enhance code clarity and maintainability without altering the existing behavior.