### PR TITLE
Update project and parent versions to 15.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>fess-ds-example</artifactId>
 	<packaging>jar</packaging>
 	<name>Example Data Store</name>
-	<version>15.0.0-SNAPSHOT</version>
+	<version>15.1.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-example.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-example.git</developerConnection>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.0.0</version>
+		<version>15.1.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
This update modifies the project version from 15.0.1-SNAPSHOT to 15.1.0-SNAPSHOT and updates the parent POM version from 15.0.0 to 15.1.0. These changes are part of the version upgrade to align with the Fess 15.1.0 release.
