### PR TITLE
Bump project and parent POM version to 15.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>fess-ds-example</artifactId>
 	<packaging>jar</packaging>
 	<name>Example Data Store</name>
-	<version>15.1.0-SNAPSHOT</version>
+	<version>15.2.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-example.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-example.git</developerConnection>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0</version>
+		<version>15.2.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
This pull request updates the project version and its parent dependency version in the `pom.xml` file to prepare for the next release cycle.

Version updates:

* Bumped the main project version from `15.1.0-SNAPSHOT` to `15.2.0-SNAPSHOT` in `pom.xml` to reflect the upcoming development version.
* Updated the parent artifact version from `15.1.0` to `15.2.0` in `pom.xml` to align with the latest parent release.