### PR TITLE
Bump project and parent POM versions to 15.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>fess-ds-example</artifactId>
 	<packaging>jar</packaging>
 	<name>Example Data Store</name>
-	<version>15.2.0-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-example.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-example.git</developerConnection>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0</version>
+		<version>15.3.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary

This PR updates the project version from 15.2.0-SNAPSHOT to 15.3.0-SNAPSHOT and updates the parent POM dependency to version 15.3.0, aligning with the latest fess-parent release.

## Changes Made

- Updated project version in pom.xml from `15.2.0-SNAPSHOT` to `15.3.0-SNAPSHOT`
- Updated parent POM `fess-parent` dependency from `15.2.0` to `15.3.0`

## Testing

- Version strings have been updated consistently across both project and parent POM references
- Build verification recommended post-merge to ensure compatibility with parent POM 15.3.0

## Breaking Changes

No breaking changes expected. This is a standard version bump following the project's release cycle.

## Additional Notes

This change follows the established pattern from previous version updates (see #6, #5).