### PR TITLE
chore: bump project and parent POM versions to 15.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>fess-ds-example</artifactId>
 	<packaging>jar</packaging>
 	<name>Example Data Store</name>
-	<version>15.3.0-SNAPSHOT</version>
+	<version>15.4.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-example.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-example.git</developerConnection>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.3.0</version>
+		<version>15.4.0</version>
 		<relativePath />
 	</parent>
 	<build>

--- a/src/test/java/org/codelibs/fess/ds/sample/SampleDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/sample/SampleDataStoreTest.java
@@ -263,9 +263,9 @@ public class SampleDataStoreTest extends LastaFluteTestCase {
             Map<String, Object> defaultDataMap = new HashMap<>();
 
             // Throw exception on first store call
-            doThrow(new CrawlingAccessException("Test exception"))
-                    .doNothing()
-                    .when(callback).store(any(DataStoreParams.class), any(Map.class));
+            doThrow(new CrawlingAccessException("Test exception")).doNothing()
+                    .when(callback)
+                    .store(any(DataStoreParams.class), any(Map.class));
 
             dataStore.storeData(dataConfig, callback, paramMap, scriptMap, defaultDataMap);
 
@@ -296,8 +296,8 @@ public class SampleDataStoreTest extends LastaFluteTestCase {
             // Create MultipleCrawlingAccessException with causes
             Throwable cause1 = new RuntimeException("Cause 1");
             Throwable cause2 = new IllegalStateException("Cause 2");
-            MultipleCrawlingAccessException exception = new MultipleCrawlingAccessException("Multiple errors",
-                    new Throwable[] { cause1, cause2 });
+            MultipleCrawlingAccessException exception =
+                    new MultipleCrawlingAccessException("Multiple errors", new Throwable[] { cause1, cause2 });
 
             doThrow(exception).when(callback).store(any(DataStoreParams.class), any(Map.class));
 
@@ -326,9 +326,7 @@ public class SampleDataStoreTest extends LastaFluteTestCase {
             DataStoreCrawlingException exception = new DataStoreCrawlingException("http://test.com", "Aborted", null, true);
 
             // Throw exception on second call
-            doNothing()
-                    .doThrow(exception)
-                    .when(callback).store(any(DataStoreParams.class), any(Map.class));
+            doNothing().doThrow(exception).when(callback).store(any(DataStoreParams.class), any(Map.class));
 
             dataStore.storeData(dataConfig, callback, paramMap, scriptMap, defaultDataMap);
 
@@ -354,9 +352,7 @@ public class SampleDataStoreTest extends LastaFluteTestCase {
             Map<String, Object> defaultDataMap = new HashMap<>();
 
             // Throw generic exception on first call
-            doThrow(new RuntimeException("Generic error"))
-                    .doNothing()
-                    .when(callback).store(any(DataStoreParams.class), any(Map.class));
+            doThrow(new RuntimeException("Generic error")).doNothing().when(callback).store(any(DataStoreParams.class), any(Map.class));
 
             dataStore.storeData(dataConfig, callback, paramMap, scriptMap, defaultDataMap);
 
@@ -407,10 +403,10 @@ public class SampleDataStoreTest extends LastaFluteTestCase {
             Map<String, Object> defaultDataMap = new HashMap<>();
 
             // Throw exception on second call
-            doNothing()
-                    .doThrow(new RuntimeException("Test error"))
+            doNothing().doThrow(new RuntimeException("Test error"))
                     .doNothing()
-                    .when(callback).store(any(DataStoreParams.class), any(Map.class));
+                    .when(callback)
+                    .store(any(DataStoreParams.class), any(Map.class));
 
             dataStore.storeData(dataConfig, callback, paramMap, scriptMap, defaultDataMap);
 


### PR DESCRIPTION
## Summary

Update project and parent POM versions to align with the upcoming Fess 15.4.0 release.

## Changes Made

- Update project version from `15.3.0-SNAPSHOT` to `15.4.0-SNAPSHOT`
- Update fess-parent version from `15.3.0` to `15.4.0`
- Apply code formatting improvements to test file (no functional changes)

## Testing

- Verified POM structure is valid
- Version bump follows established project conventions

## Additional Notes

This is a routine version bump to keep the data store extension aligned with the Fess parent project versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)